### PR TITLE
Adds hook to catch tags that don't match project version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,7 +717,7 @@ dependencies = [
  "unic",
  "url",
  "uuid",
- "versions",
+ "versions 6.3.2",
 ]
 
 [[package]]
@@ -965,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.9"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+checksum = "dd0b03af37dad7a14518b7691d81acb0f8222604ad3d1b02f6b4bed5188c0cd5"
 dependencies = [
  "serde",
 ]
@@ -2300,6 +2306,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hooks_executable"
+version = "0.2.7"
+dependencies = [
+ "anyhow",
+ "camino",
+ "strum",
+ "thiserror 1.0.69",
+ "versions 7.0.0",
+]
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3181,6 +3198,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4133,7 +4159,7 @@ dependencies = [
  "indexmap 2.9.0",
  "itertools 0.13.0",
  "lazy-regex",
- "nom",
+ "nom 7.1.3",
  "purl",
  "rattler_digest",
  "rattler_macros",
@@ -5255,9 +5281,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
@@ -5296,9 +5322,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
  "winnow",
 ]
@@ -5889,8 +5915,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139"
 dependencies = [
  "itertools 0.13.0",
- "nom",
+ "nom 7.1.3",
  "serde",
+]
+
+[[package]]
+name = "versions"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f"
+dependencies = [
+ "itertools 0.14.0",
+ "nom 8.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["bioimg_codegen", "bioimg_gui", "bioimg_spec", "bioimg_runtime", "bioimg_zoo", "task__build_webapp"]
+members = ["bioimg_codegen", "bioimg_gui", "bioimg_spec", "bioimg_runtime", "bioimg_zoo", "task__build_webapp", "hooks_executable"]
 default-members = ["bioimg_gui"]
 resolver = "2"
 

--- a/git_hooks/README.md
+++ b/git_hooks/README.md
@@ -1,0 +1,11 @@
+# Git Hooks
+
+## Installation
+
+- Link this directory as `.git/hooks/`.
+
+## How does this work?
+
+All symlink files in this directory point to `run_hook`, which compiles and runs
+the hook eecutable. To disable a hook just remove or rename any of the links
+to `run_hook`

--- a/git_hooks/pre-push
+++ b/git_hooks/pre-push
@@ -1,0 +1,1 @@
+run_hook

--- a/git_hooks/run_hook
+++ b/git_hooks/run_hook
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eux -o pipefail
+
+# run the hooks_executable crate passsing in the hook path so it can switch
+# logic based on the hook name
+cargo run -p hooks_executable -q -- "$0"

--- a/hooks_executable/Cargo.toml
+++ b/hooks_executable/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "hooks_executable"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow = "1.0.99"
+camino = "1.1.12"
+strum = { workspace = true, features = ["strum_macros", "derive"] }
+thiserror.workspace = true
+versions = "7.0.0"

--- a/hooks_executable/src/main.rs
+++ b/hooks_executable/src/main.rs
@@ -1,0 +1,59 @@
+pub mod pre_push;
+pub mod refs;
+
+use anyhow::Context;
+use camino::Utf8Path;
+use strum::EnumString;
+
+use crate::refs::GitRef;
+
+fn ensure_pushed_tag_matches_pkg_version() -> anyhow::Result<()>{
+    let pkg_version: versions::Version = env!("CARGO_PKG_VERSION").parse()
+        .context("Parsing package version")?;
+    let input = std::io::stdin();
+    for raw_entry in input.lines(){
+        let raw_entry = raw_entry.context("Reading line from stdin")?;
+        let remote_ref = match raw_entry.parse::<pre_push::UpdateArgs>(){
+            Err(_) => continue, // as a hook, we can't just explode if we don't understand the input
+            Ok(prepush_update_args) => prepush_update_args.remote_ref
+        };
+        let GitRef::Tag(tag) = remote_ref else {
+            continue
+        };
+        let Some(version) = tag.version() else {
+            continue
+        };
+        if pkg_version != version {
+            anyhow::bail!("Pushing version tag '{version}' that doesn't match workspace version '{pkg_version}'")
+        }
+    }
+    Ok(())
+}
+
+#[derive(EnumString)]
+#[strum(serialize_all = "kebab-case")]
+enum Hook{
+    PrePush,
+}
+
+impl Hook {
+    pub fn run(&self) -> anyhow::Result<()> {
+        match self{
+            Self::PrePush => ensure_pushed_tag_matches_pkg_version(),
+        }
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let mut args = std::env::args();
+    let _executable_name = args.next();
+    let Some(hook_path_raw) = args.next() else {
+        anyhow::bail!("No hook name or path passed in as first argument")
+    };
+    let hook_path = Utf8Path::new(&hook_path_raw);
+    let Some(hook_name) = hook_path.file_name() else {
+        anyhow::bail!("No hook name specified")
+    };
+    let hook: Hook = hook_name.parse().context(format!("Parsing '{hook_name}' as a git hook name"))?;
+    hook.run()
+}

--- a/hooks_executable/src/pre_push.rs
+++ b/hooks_executable/src/pre_push.rs
@@ -1,0 +1,61 @@
+use std::str::FromStr;
+
+use crate::refs::{GitRef, GitRefParsingError};
+
+
+#[derive(Debug)]
+pub struct UpdateArgs{
+    pub local_ref: GitRef,
+    pub local_object_name: String,
+    pub remote_ref: GitRef,
+    pub remote_object_name: String,
+}
+
+#[derive(Debug)]
+/// Arguments passes to pre-push that signal that a ref is to be deleted
+pub struct DeletionArgs{
+    pub remote_ref: GitRef,
+    pub remote_object_name: String,
+}
+
+pub enum PrePushEntry{
+    Update(UpdateArgs),
+    Deletion(DeletionArgs),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum PrePushArgsParsingError{
+    #[error("Too few arguments: Expecting 4 arguments for pre-push")]
+    TooFewArguments,
+    #[error("Missing local ref")]
+    MissingLocalRef,
+    #[error("Missing local object name")]
+    MissingLocalObjectName,
+    #[error("Missing remote ref")]
+    MissingRemoteRef,
+    #[error("Missing remote object name")]
+    MissingRemoteObjectName,
+    #[error("Unexpected extra arguments")]
+    UnexpectedExtraArguments,
+    #[error("Could not parse reference: {0}")]
+    GitRefParsingError(#[from] GitRefParsingError),
+}
+
+impl FromStr for UpdateArgs {
+    type Err = PrePushArgsParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split(" ");
+
+        let out = Self{
+            local_ref: parts.next().ok_or(Self::Err::MissingLocalRef)?.parse()?,
+            local_object_name: parts.next().ok_or(Self::Err::MissingLocalObjectName)?.to_owned(),
+            remote_ref: parts.next().ok_or(Self::Err::MissingRemoteRef)?.parse()?,
+            remote_object_name: parts.next().ok_or(Self::Err::MissingRemoteObjectName)?.to_owned(),
+        };
+        if parts.next().is_some() {
+            return Err(Self::Err::UnexpectedExtraArguments)
+        }
+        Ok(out)
+    }
+}

--- a/hooks_executable/src/refs.rs
+++ b/hooks_executable/src/refs.rs
@@ -1,0 +1,84 @@
+use std::str::FromStr;
+
+use camino::{Utf8Path, Utf8PathBuf};
+
+#[derive(Debug)]
+pub enum GitRef{
+    Head(GitHeadRef),
+    Tag(GitTagRef),
+}
+
+#[derive(Debug)]
+pub struct GitTagRef{
+    path: Utf8PathBuf,
+}
+impl GitTagRef{
+    pub fn name(&self) -> &str {
+        self.path.file_name().unwrap()
+    }
+    pub fn version(&self) -> Option<versions::Version>{
+        let name = self.name();
+        let name = name.strip_prefix("v")?;
+        if !name.chars().next()?.is_numeric(){
+            return None
+        }
+        name.parse::<versions::Version>().ok()
+    }
+}
+
+#[derive(Debug)]
+pub struct GitHeadRef{
+    path: Utf8PathBuf,
+}
+
+impl GitRef{
+    pub fn path(&self) -> &Utf8Path {
+        match self{
+            Self::Head(head) => &head.path,
+            Self::Tag(tag) => &tag.path,
+        }
+    }
+    pub fn name(&self) -> &str {
+        self.path().file_name().unwrap()
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum GitRefParsingError{
+    #[error("Value has no path components")]
+    NoComponents,
+    #[error("Value doesn't start with a 'refs' component: {0}")]
+    DoesntStartWithRefs(String),
+    #[error("Value doesn't have a component after 'refs' indicating a category")]
+    NoCategory,
+    #[error("Git ref cateogry not regognized: {0}")]
+    CategoryParsingError(String),
+    #[error("Refenrece path has no name (too few components)")]
+    NoRefName,
+}
+
+impl FromStr for GitRef{
+    type Err = GitRefParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let path = Utf8Path::new(s);
+        let mut components = path.components();
+        let first_component = components.next().ok_or(Self::Err::NoComponents)?;
+        if first_component.as_str() != "refs" {
+            return Err(Self::Err::DoesntStartWithRefs(path.as_str().to_owned()))
+        }
+        let raw_ref_category = components.next().ok_or(Self::Err::NoCategory)?;
+        if components.next().is_none(){
+            return Err(Self::Err::NoCategory);
+        }
+        Ok(match raw_ref_category.as_str() {
+            "tags" => Self::Tag(GitTagRef{ path: path.to_owned() }),
+            "heads" => Self::Head(GitHeadRef{ path: path.to_owned() }),
+            _ => {
+                return Err(Self::Err::CategoryParsingError(raw_ref_category.as_str().to_owned()))
+            },
+        })
+    }
+}
+
+


### PR DESCRIPTION
Adds a pre-push hook to catch when tags are being pushed when they don't match the project version. The hooks live in `git_hooks`, which should be linked as `.git/hooks`. On execution, they run

`cargo run -p hooks_executable -- $THE_HOOK_NAME`

and the executable switches logic on the hook name. Adding hooks is a matter of implementing them in the `hook_executable` crate and creating the symlink with the appropriate hook name in `git_hooks/`